### PR TITLE
fixed icons overlapping text in teams section

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -766,9 +766,9 @@ section {
   top: calc(50% - 30px);
 }
 
-.services .icon i {
-  font-size: 64px;
+.team .icon i {
   line-height: 1;
+  padding: 0;
   transition: 0.5s;
 }
 


### PR DESCRIPTION
Fixed the icons that were overlapping texts in the services section
look at the images below to see the before and after the result 

PS- please add hacktoberfest to this PR

Before:
![image](https://user-images.githubusercontent.com/91624754/193681526-d62ed3c2-4b5d-42d6-ba6b-9760d22f5a8b.png)
![image](https://user-images.githubusercontent.com/91624754/193681559-470c57f1-9f2e-4666-943a-ad6bf85b6613.png)

After:
![image](https://user-images.githubusercontent.com/91624754/193681612-ad88a999-93c2-444b-ad37-ca0edda533e1.png)
![image](https://user-images.githubusercontent.com/91624754/193681639-e60bf1c8-f0a4-42a3-93ce-ede34e39443a.png)
